### PR TITLE
[ENH] Fix non-connection on startup for rebooted iocs

### DIFF
--- a/prosilicaApp/src/prosilica.cpp
+++ b/prosilicaApp/src/prosilica.cpp
@@ -1450,10 +1450,6 @@ asynStatus prosilica::connectCamera()
      * and this can happen if the camera was acquiring when the IOC previously exited. */
     PvCommandRun(this->PvHandle, "AcquisitionAbort");
     
-    /* Now sync the timer of the camera and the IOC */
-
-    this->syncTimer();
-
     /* We found the camera and everything is OK.  Signal to asynManager that we are connected. */
     status = pasynManager->exceptionConnect(this->pasynUserSelf);
     if (status) {

--- a/prosilicaApp/src/prosilica.cpp
+++ b/prosilicaApp/src/prosilica.cpp
@@ -1304,6 +1304,27 @@ asynStatus prosilica::connectCamera()
         this->uniqueId = this->PvCameraInfo.UniqueId;
     }
 
+    // Here's where reconnect fails.
+    // PermittedAccess flags are 0x0002 for around 5 seconds after
+    // a hard IOC restart which didn't call disconnectCamera()
+    unsigned retryCount = 0;
+    while ( (this->PvCameraInfo.PermittedAccess & ePvAccessMaster) == 0 ) {
+        asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, 
+              "%s:%s: No RW access for camera %lu, retrying ...\n", 
+              driverName, functionName, this->uniqueId);
+
+        // Wait a second and fetch status again
+        epicsThreadSleep(1);
+        status = PvCameraInfoEx(this->uniqueId, &this->PvCameraInfo, sizeof(this->PvCameraInfo));
+        if (status) {
+            asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, 
+                  "%s:%s: Cannot read status for camera %lu\n", 
+                  driverName, functionName, this->uniqueId);
+            return asynError;
+        }
+        if ( ++retryCount >= 10 )
+            break;
+    }
     if ((this->PvCameraInfo.PermittedAccess & ePvAccessMaster) == 0) {
         asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, 
               "%s:%s: Cannot get control of camera %lu, access flags=%lx\n", 
@@ -1323,7 +1344,7 @@ asynStatus prosilica::connectCamera()
         this->PvHandle = NULL;
         return asynError;
     }
-    
+ 
     /* Negotiate maximum frame size */
     status = PvCaptureAdjustPacketSize(this->PvHandle, MAX_PACKET_SIZE);
     if (status) {
@@ -1796,22 +1817,24 @@ prosilica::prosilica(const char *portName, const char *cameraId, int maxBuffers,
 
         PvApiInitialized = 1;
     }
-    
-    /* Need to wait a short while for the PvAPI library to find the cameras (0.2 seconds is not long enough in 1.24) */
+
+    /* Need to wait a short while for the PvAPI library to find the cameras */
+    /* (0.2 seconds is not long enough in 1.24) */
     epicsThreadSleep(1.0);
-    
-    /* Try to connect to the camera.  
-     * It is not a fatal error if we cannot now, the camera may be off or owned by
-     * someone else.  It may connect later. */
-    this->lock();
-    status = connectCamera();
-    this->unlock();
-    if (status) {
-        printf("%s:%s: cannot connect to camera %s, manually connect when available.\n", 
-               driverName, functionName, cameraId);
-        return;
+ 
+    if ( this->PvHandle == NULL ) {
+        /* Try to connect to the camera.  
+         * It is not a fatal error if we cannot now, the camera may be off or owned by
+         * someone else.  It may connect later. */
+        this->lock();
+        status = connectCamera();
+        this->unlock();
+        if (status) {
+            printf("%s:%s: cannot connect to camera %s, manually connect when available.\n", 
+                   driverName, functionName, cameraId);
+        }
     }
-    
+ 
     /* Register the shutdown function for epicsAtExit */
     epicsAtExit(shutdown, (void*)this);
 }


### PR DESCRIPTION
The following - tested - will keep trying to reconnect to the camera on startup if the camera indicated that it is not permitted to connect. This adds a 5 to 10s delay to startup but ensures that the camera comes up in a connected state. 

This is particularly useful when the IOC is run with procServ and the IOC is hard rebooted. 

Note: This is the same as Pull Request #6, with formatting changes 

Thanks @bhill-slac!