### PR TITLE
Timestamp additions / fixes

### DIFF
--- a/prosilicaApp/Db/prosilica.template
+++ b/prosilicaApp/Db/prosilica.template
@@ -854,6 +854,8 @@ record(mbbo, "$(P)$(R)PSTimestampType")
    field(TWVL, "2")
    field(THST, "EPICS")
    field(THVL, "3")
+   field(THST, "IOC")
+   field(THVL, "4")
    field(VAL, "0")
    field(PINI, "YES")
 }
@@ -870,6 +872,8 @@ record(mbbi, "$(P)$(R)PSTimestampType_RBV")
    field(TWVL, "2")
    field(THST, "EPICS")
    field(THVL, "3")
+   field(THST, "IOC")
+   field(THVL, "4")
    field(SCAN, "I/O Intr")
 }
 

--- a/prosilicaApp/src/prosilica.cpp
+++ b/prosilicaApp/src/prosilica.cpp
@@ -1422,6 +1422,10 @@ asynStatus prosilica::connectCamera()
      * With CMOS cameras if the camera is already acquiring when we connect there will be problems,
      * and this can happen if the camera was acquiring when the IOC previously exited. */
     PvCommandRun(this->PvHandle, "AcquisitionAbort");
+
+    /* Now sync the timer on the camera with the IOC */
+
+    this->syncTimer();
         
     /* We found the camera and everything is OK.  Signal to asynManager that we are connected. */
     status = pasynManager->exceptionConnect(this->pasynUserSelf);

--- a/prosilicaApp/src/prosilica.cpp
+++ b/prosilicaApp/src/prosilica.cpp
@@ -744,9 +744,8 @@ void prosilica::frameCallback(tPvFrame *pFrame)
                 break;
 
             case PSTimestampTypeIOC: {
-                    timespec ts;
-                    epicsTimeToTimespec(&ts, &pImage->epicsTS);
-                    pImage->timeStamp = (double)ts.tv_sec + ((double)ts.tv_nsec * 1.0e-9);
+                    pImage->timeStamp = (double)pImage->epicsTS.secPastEpoch 
+                      + ((double)pImage->epicsTS.nsec * 1.0e-9);
                 }
                 break;
 


### PR DESCRIPTION
This PR does come cleanup with the timestamping for the Prosilica. 

1) The function ```syncTimer()``` is called on successful camera connect. This ensures that the synced timestamp options to set the ```pImage->timeStamp``` are actually synced. Currently if the PV associated with syncing the timestamp is not set, this is uninitialized. 

2) Added a new option which is IOC time. This ensures that the EPICS timestamp and the ```pImage->timeStamp``` are in sync. For most users I can see this as being the default option.

3) The other modes (sync the camera with IOC) can be used when absolute precision between frames is needed and these are left as is. 

One consideration would be to now make the "IOC" option the default ..... Thoughts?