### PR TITLE
Temperature readout if supported by camera

### DIFF
--- a/prosilicaApp/Db/prosilica.template
+++ b/prosilicaApp/Db/prosilica.template
@@ -950,18 +950,11 @@ record(longout, "$(P)$(R)PSResetTimer")
 ###############################################################################
 #  These records are for temperature readout                                  #
 ###############################################################################
-record(ai, "$(P)$(R)TemperatureSensor_RBV")
-{
-   field(DTYP, "asynFloat64")
-   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PS_TEMPERATURE_SENSOR")
-   field(PREC, "2")
-   field(SCAN, "I/O Intr")
-}
-
 record(ai, "$(P)$(R)TemperatureMainboard_RBV")
 {
    field(DTYP, "asynFloat64")
    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PS_TEMPERATURE_MAINBOARD")
-   field(PREC, "2")
+   field(PREC, "1")
+   field(EGU,  "C")
    field(SCAN, "I/O Intr")
 }

--- a/prosilicaApp/Db/prosilica.template
+++ b/prosilicaApp/Db/prosilica.template
@@ -947,3 +947,21 @@ record(longout, "$(P)$(R)PSResetTimer")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PS_RESET_TIMER")
 }
 
+###############################################################################
+#  These records are for temperature readout                                  #
+###############################################################################
+record(ai, "$(P)$(R)TemperatureSensor_RBV")
+{
+   field(DTYP, "asynFloat64")
+   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PS_TEMPERATURE_SENSOR")
+   field(PREC, "2")
+   field(SCAN, "I/O Intr")
+}
+
+record(ai, "$(P)$(R)TemperatureMainboard_RBV")
+{
+   field(DTYP, "asynFloat64")
+   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PS_TEMPERATURE_MAINBOARD")
+   field(PREC, "2")
+   field(SCAN, "I/O Intr")
+}

--- a/prosilicaApp/src/prosilica.cpp
+++ b/prosilicaApp/src/prosilica.cpp
@@ -121,8 +121,7 @@ protected:
     int PSStrobe1CtlDuration;
     int PSStrobe1Duration;
     int PSTemperatureMainboard;
-    int PSTemperatureSensor;
-    #define LAST_PS_PARAM PSTemperatureSensor
+    #define LAST_PS_PARAM PSTemperatureMainboard
 private:                                        
     /* These are the methods that are new to this class */
     asynStatus setPixelFormat();
@@ -312,7 +311,6 @@ static const char *PSGainModes[] = {
 #define PSStrobe1CtlDurationString   "PS_STROBE_1_CTL_DURATION"/* (asynInt32,    r/w) Strobe 1 controlled duration */
 #define PSStrobe1DurationString      "PS_STROBE_1_DURATION"    /* (asynFloat64,  r/w) Strobe 1 duration */
 #define PSTemperatureMainboardString "PS_TEMPERATURE_MAINBOARD"/* (asynFloat64,  r/o) Device temperature mainboard*/
-#define PSTemperatureSensorString    "PS_TEMPERATURE_SENSOR"   /* (asynFloat64,  r/o) Device temperature sensor */
 
 
 void prosilica::shutdown (void* arg) {
@@ -1080,9 +1078,9 @@ asynStatus prosilica::readStats()
     /* This parameter can be not supported */
     if (status == ePvErrNotFound) {
         status = 0;
-        status |= setDoubleParam(PSTemperatureSensor, 0.);
+        status |= setDoubleParam(ADTemperatureActual, 0.);
     } else if (status == 0) {
-        status |= setDoubleParam(PSTemperatureSensor, fval);
+        status |= setDoubleParam(ADTemperatureActual, fval);
     }
 
     status |= PvAttrEnumGet(this->PvHandle, "SyncOut1Invert", buffer, sizeof(buffer), &nchars);
@@ -1896,7 +1894,6 @@ prosilica::prosilica(const char *portName, const char *cameraId, int maxBuffers,
     createParam(PSStrobe1CtlDurationString,  asynParamInt32,    &PSStrobe1CtlDuration);
     createParam(PSStrobe1DurationString,     asynParamFloat64,  &PSStrobe1Duration);
     createParam(PSTemperatureMainboardString,asynParamFloat64,  &PSTemperatureMainboard);
-    createParam(PSTemperatureSensorString,   asynParamFloat64,  &PSTemperatureSensor);
 
     /* There is a conflict with readline use of signals, don't use readline signal handlers */
 #ifdef linux

--- a/prosilicaApp/src/prosilica.cpp
+++ b/prosilicaApp/src/prosilica.cpp
@@ -120,7 +120,9 @@ protected:
     int PSStrobe1Delay;
     int PSStrobe1CtlDuration;
     int PSStrobe1Duration;
-    #define LAST_PS_PARAM PSStrobe1Duration
+    int PSTemperatureMainboard;
+    int PSTemperatureSensor;
+    #define LAST_PS_PARAM PSTemperatureSensor
 private:                                        
     /* These are the methods that are new to this class */
     asynStatus setPixelFormat();
@@ -309,6 +311,9 @@ static const char *PSGainModes[] = {
 #define PSStrobe1DelayString         "PS_STROBE_1_DELAY"       /* (asynFloat64,  r/w) Strobe 1 delay */
 #define PSStrobe1CtlDurationString   "PS_STROBE_1_CTL_DURATION"/* (asynInt32,    r/w) Strobe 1 controlled duration */
 #define PSStrobe1DurationString      "PS_STROBE_1_DURATION"    /* (asynFloat64,  r/w) Strobe 1 duration */
+#define PSTemperatureMainboardString "PS_TEMPERATURE_MAINBOARD"/* (asynFloat64,  r/o) Device temperature mainboard*/
+#define PSTemperatureSensorString    "PS_TEMPERATURE_SENSOR"   /* (asynFloat64,  r/o) Device temperature sensor */
+
 
 void prosilica::shutdown (void* arg) {
 
@@ -1062,6 +1067,24 @@ asynStatus prosilica::readStats()
         }
     }
     
+    /* Device Temperature */
+    status |=  PvAttrFloat32Get(this->PvHandle, "DeviceTemperatureMainboard", &fval);
+    /* This parameter can be not supported */
+    if (status == ePvErrNotFound) {
+        status = 0;
+        status |= setDoubleParam(PSTemperatureMainboard, 0.);
+    } else if (status == 0) {
+        status |= setDoubleParam(PSTemperatureMainboard, fval);
+    }
+    status |=  PvAttrFloat32Get(this->PvHandle, "DeviceTemperatureSensor", &fval);
+    /* This parameter can be not supported */
+    if (status == ePvErrNotFound) {
+        status = 0;
+        status |= setDoubleParam(PSTemperatureSensor, 0.);
+    } else if (status == 0) {
+        status |= setDoubleParam(PSTemperatureSensor, fval);
+    }
+
     status |= PvAttrEnumGet(this->PvHandle, "SyncOut1Invert", buffer, sizeof(buffer), &nchars);
     if (strcmp(buffer, "Off") == 0) i = 0;
     else if (strcmp(buffer, "On") == 0) i = 1;
@@ -1241,7 +1264,7 @@ asynStatus prosilica::readParameters()
         status |= setIntegerParam(PSGainMode, 0);
         status |= asynError;
     }
- 
+
     /* Call the callbacks to update the values in higher layers */
     callParamCallbacks();
     
@@ -1833,45 +1856,47 @@ prosilica::prosilica(const char *portName, const char *cameraId, int maxBuffers,
     }
     pNode->pCamera = this;
     ellAdd(cameraList, (ELLNODE *)pNode);
-    
-    createParam(PSReadStatisticsString,    asynParamInt32,    &PSReadStatistics);
-    createParam(PSBayerConvertString,      asynParamInt32,    &PSBayerConvert);
-    createParam(PSGainModeString,          asynParamInt32,    &PSGainMode);
-    createParam(PSExposureModeString,      asynParamInt32,    &PSExposureMode);
-    createParam(PSDriverTypeString,        asynParamOctet,    &PSDriverType);
-    createParam(PSFilterVersionString,     asynParamOctet,    &PSFilterVersion);
-    createParam(PSTimestampTypeString,     asynParamInt32,    &PSTimestampType);
-    createParam(PSResetTimerString,        asynParamInt32,    &PSResetTimer);
-    createParam(PSFrameRateString,         asynParamFloat64,  &PSFrameRate);
-    createParam(PSByteRateString,          asynParamInt32,    &PSByteRate);
-    createParam(PSPacketSizeString,        asynParamInt32,    &PSPacketSize);
-    createParam(PSFramesCompletedString,   asynParamInt32,    &PSFramesCompleted);
-    createParam(PSFramesDroppedString,     asynParamInt32,    &PSFramesDropped);
-    createParam(PSPacketsErroneousString,  asynParamInt32,    &PSPacketsErroneous);
-    createParam(PSPacketsMissedString,     asynParamInt32,    &PSPacketsMissed);
-    createParam(PSPacketsReceivedString,   asynParamInt32,    &PSPacketsReceived);
-    createParam(PSPacketsRequestedString,  asynParamInt32,    &PSPacketsRequested);
-    createParam(PSPacketsResentString,     asynParamInt32,    &PSPacketsResent);
-    createParam(PSBadFrameCounterString,   asynParamInt32,    &PSBadFrameCounter);
-    createParam(PSTriggerDelayString,      asynParamFloat64,  &PSTriggerDelay);
-    createParam(PSTriggerEventString,      asynParamInt32,    &PSTriggerEvent);
-    createParam(PSTriggerOverlapString,    asynParamInt32,    &PSTriggerOverlap);
-    createParam(PSTriggerSoftwareString,   asynParamInt32,    &PSTriggerSoftware);
-    createParam(PSSyncIn1LevelString,      asynParamInt32,    &PSSyncIn1Level);
-    createParam(PSSyncIn2LevelString,      asynParamInt32,    &PSSyncIn2Level);
-    createParam(PSSyncOut1ModeString,      asynParamInt32,    &PSSyncOut1Mode);
-    createParam(PSSyncOut1LevelString,     asynParamInt32,    &PSSyncOut1Level);
-    createParam(PSSyncOut1InvertString,    asynParamInt32,    &PSSyncOut1Invert);
-    createParam(PSSyncOut2ModeString,      asynParamInt32,    &PSSyncOut2Mode);
-    createParam(PSSyncOut2LevelString,     asynParamInt32,    &PSSyncOut2Level);
-    createParam(PSSyncOut2InvertString,    asynParamInt32,    &PSSyncOut2Invert);
-    createParam(PSSyncOut3ModeString,      asynParamInt32,    &PSSyncOut3Mode);
-    createParam(PSSyncOut3LevelString,     asynParamInt32,    &PSSyncOut3Level);
-    createParam(PSSyncOut3InvertString,    asynParamInt32,    &PSSyncOut3Invert);
-    createParam(PSStrobe1ModeString,       asynParamInt32,    &PSStrobe1Mode);
-    createParam(PSStrobe1DelayString,      asynParamFloat64,  &PSStrobe1Delay);
-    createParam(PSStrobe1CtlDurationString,asynParamInt32,    &PSStrobe1CtlDuration);
-    createParam(PSStrobe1DurationString,   asynParamFloat64,  &PSStrobe1Duration);
+ 
+    createParam(PSReadStatisticsString,      asynParamInt32,    &PSReadStatistics);
+    createParam(PSBayerConvertString,        asynParamInt32,    &PSBayerConvert);
+    createParam(PSGainModeString,            asynParamInt32,    &PSGainMode);
+    createParam(PSExposureModeString,        asynParamInt32,    &PSExposureMode);
+    createParam(PSDriverTypeString,          asynParamOctet,    &PSDriverType);
+    createParam(PSFilterVersionString,       asynParamOctet,    &PSFilterVersion);
+    createParam(PSTimestampTypeString,       asynParamInt32,    &PSTimestampType);
+    createParam(PSResetTimerString,          asynParamInt32,    &PSResetTimer);
+    createParam(PSFrameRateString,           asynParamFloat64,  &PSFrameRate);
+    createParam(PSByteRateString,            asynParamInt32,    &PSByteRate);
+    createParam(PSPacketSizeString,          asynParamInt32,    &PSPacketSize);
+    createParam(PSFramesCompletedString,     asynParamInt32,    &PSFramesCompleted);
+    createParam(PSFramesDroppedString,       asynParamInt32,    &PSFramesDropped);
+    createParam(PSPacketsErroneousString,    asynParamInt32,    &PSPacketsErroneous);
+    createParam(PSPacketsMissedString,       asynParamInt32,    &PSPacketsMissed);
+    createParam(PSPacketsReceivedString,     asynParamInt32,    &PSPacketsReceived);
+    createParam(PSPacketsRequestedString,    asynParamInt32,    &PSPacketsRequested);
+    createParam(PSPacketsResentString,       asynParamInt32,    &PSPacketsResent);
+    createParam(PSBadFrameCounterString,     asynParamInt32,    &PSBadFrameCounter);
+    createParam(PSTriggerDelayString,        asynParamFloat64,  &PSTriggerDelay);
+    createParam(PSTriggerEventString,        asynParamInt32,    &PSTriggerEvent);
+    createParam(PSTriggerOverlapString,      asynParamInt32,    &PSTriggerOverlap);
+    createParam(PSTriggerSoftwareString,     asynParamInt32,    &PSTriggerSoftware);
+    createParam(PSSyncIn1LevelString,        asynParamInt32,    &PSSyncIn1Level);
+    createParam(PSSyncIn2LevelString,        asynParamInt32,    &PSSyncIn2Level);
+    createParam(PSSyncOut1ModeString,        asynParamInt32,    &PSSyncOut1Mode);
+    createParam(PSSyncOut1LevelString,       asynParamInt32,    &PSSyncOut1Level);
+    createParam(PSSyncOut1InvertString,      asynParamInt32,    &PSSyncOut1Invert);
+    createParam(PSSyncOut2ModeString,        asynParamInt32,    &PSSyncOut2Mode);
+    createParam(PSSyncOut2LevelString,       asynParamInt32,    &PSSyncOut2Level);
+    createParam(PSSyncOut2InvertString,      asynParamInt32,    &PSSyncOut2Invert);
+    createParam(PSSyncOut3ModeString,        asynParamInt32,    &PSSyncOut3Mode);
+    createParam(PSSyncOut3LevelString,       asynParamInt32,    &PSSyncOut3Level);
+    createParam(PSSyncOut3InvertString,      asynParamInt32,    &PSSyncOut3Invert);
+    createParam(PSStrobe1ModeString,         asynParamInt32,    &PSStrobe1Mode);
+    createParam(PSStrobe1DelayString,        asynParamFloat64,  &PSStrobe1Delay);
+    createParam(PSStrobe1CtlDurationString,  asynParamInt32,    &PSStrobe1CtlDuration);
+    createParam(PSStrobe1DurationString,     asynParamFloat64,  &PSStrobe1Duration);
+    createParam(PSTemperatureMainboardString,asynParamFloat64,  &PSTemperatureMainboard);
+    createParam(PSTemperatureSensorString,   asynParamFloat64,  &PSTemperatureSensor);
 
     /* There is a conflict with readline use of signals, don't use readline signal handlers */
 #ifdef linux


### PR DESCRIPTION
Readout of Main board and sensor temperature if it's supported by camera. If it's not supported by camera the temperatures are set to 0. The readout procedure is written in prosilica::readStats() function. Tested on Procilica GC1380 and GT1380 cameras.

The new PV names for readout:
$(P)$(R)TemperatureSensor_RBV
$(P)$(R)TemperatureMainboard_RBV