### PR TITLE
fix legacy SDK name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ who purchased Prosilica.
 The driver is supported under Windows, Linux and Mac OS X using the 
 vendor library provided for those operating systems.
 
-**NOTE:** This driver uses the obsolete Prosilica FlyCap2 SDK.
+**NOTE:** This driver uses the legacy Prosilica PvAPI SDK.
 Users are encouraged to switch to the [ADVimba](https://github.com/areaDetector/ADVimba) driver,
 which uses the newer AVT Vimba SDK.
 


### PR DESCRIPTION
fix the SDK naming according to https://www.alliedvision.com/en/support/software-downloads#c1556